### PR TITLE
fix: correctly set tokenType

### DIFF
--- a/src/DiscordClient.php
+++ b/src/DiscordClient.php
@@ -160,6 +160,7 @@ class DiscordClient
                     if (0 === stripos($value, 'Bearer ')) {
                         $value                = substr($value, 7);
                     }
+                    
                     return $value;
                 }
             )
@@ -177,6 +178,7 @@ class DiscordClient
                     } else {
                         $value = '';
                     }
+                    
                     return $value;
                 }
             );

--- a/src/DiscordClient.php
+++ b/src/DiscordClient.php
@@ -160,7 +160,7 @@ class DiscordClient
                     if (0 === stripos($value, 'Bearer ')) {
                         $value                = substr($value, 7);
                     }
-                    
+
                     return $value;
                 }
             )
@@ -178,7 +178,7 @@ class DiscordClient
                     } else {
                         $value = '';
                     }
-                    
+
                     return $value;
                 }
             );

--- a/src/DiscordClient.php
+++ b/src/DiscordClient.php
@@ -156,17 +156,10 @@ class DiscordClient
                 function (Options $options, $value) {
                     if (0 === stripos($value, 'Bot ')) {
                         $value                = substr($value, 4);
-                        $options['tokenType'] = 'Bot';
                     }
                     if (0 === stripos($value, 'Bearer ')) {
                         $value                = substr($value, 7);
-                        $options['tokenType'] = 'OAuth';
                     }
-
-                    if (empty($value)) {
-                        $options['tokenType'] = 'None';
-                    }
-
                     return $value;
                 }
             )
@@ -176,13 +169,14 @@ class DiscordClient
                     if ($options['token'] !== null && $value === 'None') {
                         $value = 'Bot';
                     }
-
+                    if ($options['tokenType'] === 'OAuth') {
+                        $value = 'Bearer';
+                    }
                     if ($value !== 'User') {
                         $value .= ' ';
                     } else {
                         $value = '';
                     }
-
                     return $value;
                 }
             );


### PR DESCRIPTION
Settings options directly by accessing `$options` array is not allowed. 

Only tested with OAuth so far.