### PR TITLE
Make sure to retrieve the correct token type.

### DIFF
--- a/src/DiscordClient.php
+++ b/src/DiscordClient.php
@@ -92,7 +92,7 @@ class DiscordClient
             )
         );
 
-        $defaultGuzzleOptions           = [
+        $defaultGuzzleOptions = [
             'headers'     => [
                 'Authorization' => $this->getAuthorizationHeader($this->options['tokenType'], $this->options['token']),
                 'User-Agent'    => "DiscordBot (https://github.com/aequasi/php-restcord, {$this->getVersion()})",
@@ -176,12 +176,6 @@ class DiscordClient
                 function (Options $options, $value) {
                     if ($options['token'] !== null && $value === 'None') {
                         $value = 'Bot';
-                    }
-
-                    if ($value !== 'User') {
-                        $value .= ' ';
-                    } else {
-                        $value = '';
                     }
 
                     return $value;


### PR DESCRIPTION
There was an error determining the correct token type.

If you for example did the following:
```php
$discord = new \RestCord\DiscordClient([
    'token' => $someToken,
    'tokenType' => 'OAuth'
]);
```

The `validateOptions` method would turn `OAuth` into "OAuth " (with a space) then in `getAuthorizationHeader` the switch/case would use the default value which is `Bot`.

If the `tokenType` is `User` there is no need to remove that in `validateOptions` too, since that is being handled by `getAuthorizationHeader` correctly.