### PR TITLE
Strip whitespaces from tokenType

### DIFF
--- a/src/DiscordClient.php
+++ b/src/DiscordClient.php
@@ -426,7 +426,7 @@ class DiscordClient
      */
     private function getAuthorizationHeader($tokenType, $token)
     {
-        switch ($tokenType) {
+        switch (str_replace(' ' , '', $tokenType)) {
             default:
                 $authorization = 'Bot ';
                 break;

--- a/src/DiscordClient.php
+++ b/src/DiscordClient.php
@@ -426,7 +426,7 @@ class DiscordClient
      */
     private function getAuthorizationHeader($tokenType, $token)
     {
-        switch (str_replace(' ' , '', $tokenType)) {
+        switch (str_replace(' ', '', $tokenType)) {
             default:
                 $authorization = 'Bot ';
                 break;


### PR DESCRIPTION
This will set the correct authorization header in the actual request instead of using "Bot " by default.