### PR TITLE
Handle null body responses correctly

### DIFF
--- a/src/DiscordClient.php
+++ b/src/DiscordClient.php
@@ -252,6 +252,7 @@ class DiscordClient
                 return new Result(json_decode($content, true));
             } catch (\Exception $e) {
                 dump($response->getBody()->__toString());
+
                 throw $e;
             }
         }
@@ -268,6 +269,9 @@ class DiscordClient
 
         if (!class_exists($class)) {
             return new Result($data);
+        }
+        if ($data === null) {
+            return new Result([]);
         }
 
         $mapper                   = new \JsonMapper();


### PR DESCRIPTION
It is possible for Discord to return a successful response code (200) and no body. (For example: attempting to use a bot's context to fiddle with its owner's roles or guilds will send this response.)

This correctly detects an empty body response and returns an empty Result object without failing inside of Guzzle attempting to convert NULL to the expected class type.