### PR TITLE
Guzzle's http_errors setting can now be overriden

### DIFF
--- a/src/DiscordClient.php
+++ b/src/DiscordClient.php
@@ -99,7 +99,7 @@ class DiscordClient
                 'User-Agent'    => "DiscordBot (https://github.com/aequasi/php-restcord, {$this->getVersion()})",
                 'Content-Type'  => 'application/json',
             ],
-            'http_errors' => isset($this->options['httpErrors']) ? $this->options['httpErrors'] : false,
+            'http_errors' => isset($this->options['httpErrors']) ? $this->options['httpErrors'] : true,
             'handler'     => $stack,
         ];
         $this->options['guzzleOptions'] = array_merge($this->options['guzzleOptions'], $defaultGuzzleOptions);

--- a/src/DiscordClient.php
+++ b/src/DiscordClient.php
@@ -99,7 +99,7 @@ class DiscordClient
                 'User-Agent'    => "DiscordBot (https://github.com/aequasi/php-restcord, {$this->getVersion()})",
                 'Content-Type'  => 'application/json',
             ],
-            'http_errors' => false,
+            'http_errors' => isset($this->options['httpErrors']) ? $this->options['httpErrors'] : false,
             'handler'     => $stack,
         ];
         $this->options['guzzleOptions'] = array_merge($this->options['guzzleOptions'], $defaultGuzzleOptions);


### PR DESCRIPTION
Currently exceptions are not thrown on 4XX responses due to this guzzle setting being disabled.  This PR enables the ability for applications to override this setting while ~maintaining the library default of `false`~ updating the library default to throw exceptions.