### PR TITLE
Fix forced space at the end of token types other than User

### DIFF
--- a/src/DiscordClient.php
+++ b/src/DiscordClient.php
@@ -179,12 +179,6 @@ class DiscordClient
                         $value = 'Bot';
                     }
 
-                    if ($value !== 'User') {
-                        $value .= ' ';
-                    } else {
-                        $value = '';
-                    }
-
                     return $value;
                 }
             );


### PR DESCRIPTION
The normalizer in `validateOptions` explicitly adds a space to the end of the token type if it isn't `"User"`, but `getAuthorizationHeader` decides the token prefix based on the `tokenType` without the additional space (which is fine in itself) but this results in all requests using the `getAuthorizationHeader`'s default branch which makes the token `Bot` no matter what. I spent 2 hours trying to figure out why I was getting 401s using an OAuth token until I dumped `$this->options` and saw this:

```
array (8) [
    'cacheDir' => string (85) "/home/username/project/vendor/restcord/restcord/src/../../../cache/"
    'version' => integer 6
    'logger' => Monolog\Logger (4) (
        protected 'handlers' -> array (0) []
        protected 'microsecondTimestamps' -> boolean true
        protected 'name' -> string (6) "Logger"
        protected 'processors' -> array (0) []
    )
    'throwOnRatelimit' => boolean false
    'apiUrl' => string (30) "https://discordapp.com/api/v6/"
    'token' => string (30) "<redacted>"
    'tokenType' => string (6) "OAuth "
    'guzzleOptions' => array (0) []
]
```

This PR removes the manipulation of the `tokenType` option and leaves the original handling in `getAuthorizationHeader` intact.