### PR TITLE
Changed variable type of GuildMember->joined_at to string from int

### DIFF
--- a/src/Model/Guild/GuildMember.php
+++ b/src/Model/Guild/GuildMember.php
@@ -28,7 +28,7 @@ class GuildMember {
 	/**
 	 * when the user joined the guild
 	 *
-	 * @var int
+	 * @var string|null
 	 */
 	public $joined_at;
 


### PR DESCRIPTION
joined_at is a datetime returned from Discord. Such as "2018-05-04T14:27:08.356000+00:00" as an int type this was being returned as "2018". As a string, the whole datetime is returned.