### PR TITLE
cleaning dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,16 +4,11 @@
     "type":         "library",
     "require":      {
         "php":                        "^5.6|^7.0",
-        "doctrine/annotations":       "^1.3",
-        "doctrine/cache":             "^1.4",
-        "doctrine/common":            "^2.3",
         "guzzlehttp/guzzle":          "^6.3",
         "guzzlehttp/guzzle-services": "^1.0",
-        "league/fractal":             "^0.15.0",
         "monolog/monolog":            "^1.22",
         "netresearch/jsonmapper":     "^1.4",
-        "symfony/options-resolver":   "^2.6|^3.0|^4.0",
-        "twig/twig":                  "^1.20|^2.0"
+        "symfony/options-resolver":   "^2.6|^3.0|^4.0"
     },
     "autoload":     {
         "psr-4": {
@@ -38,6 +33,7 @@
         "symfony/console":          "^2.6|^3.0|^4.0",
         "symfony/process":          "^2.6|^3.0|^4.0",
         "symfony/var-dumper":       "^2.6|^3.0|^4.0",
+        "twig/twig":                "^1.20|^2.0",
         "phpunit/phpunit":          "^6.0|^5.0"
     }
 }

--- a/src/DiscordClient.php
+++ b/src/DiscordClient.php
@@ -21,7 +21,6 @@ use GuzzleHttp\Command\Result;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use Monolog\Logger;
-use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use RestCord\Logging\MessageFormatter;
 use RestCord\RateLimit\Provider\AbstractRateLimitProvider;

--- a/src/OverriddenGuzzleClient.php
+++ b/src/OverriddenGuzzleClient.php
@@ -13,7 +13,6 @@
 
 namespace RestCord;
 
-use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Command\Command;
 use GuzzleHttp\Command\Guzzle\DescriptionInterface;


### PR DESCRIPTION
As said on discord; I've see no usage of doctrines packages.
Therefore, I remove them from the composer.

Also, move twig requirement into require-dev since it used only in order to build doc.

I've doubt about fractal. Think you replaced it by jsonmapper.