### PR TITLE
fix decode error due to empty content

### DIFF
--- a/src/DiscordClient.php
+++ b/src/DiscordClient.php
@@ -226,7 +226,11 @@ class DiscordClient
             }
         }
 
-        $data         = json_decode($response->getBody()->__toString());
+        // attempt to deserialize into JSON only if there is a content in the response
+        $data = null;
+        if ($response->getStatusCode() != 204)
+            $data         = json_decode($response->getBody()->__toString());
+
         $array        = strpos($operation['responseTypes'][0]['type'], 'Array') !== false;
         $responseType = $operation['responseTypes'][0]['type'];
         if ($array) {

--- a/src/DiscordClient.php
+++ b/src/DiscordClient.php
@@ -228,8 +228,9 @@ class DiscordClient
 
         // attempt to deserialize into JSON only if there is a content in the response
         $data = null;
-        if ($response->getStatusCode() != 204)
-            $data         = json_decode($response->getBody()->__toString());
+        if ($response->getStatusCode() !== 204) {
+            $data = json_decode($response->getBody()->__toString());
+        }
 
         $array        = strpos($operation['responseTypes'][0]['type'], 'Array') !== false;
         $responseType = $operation['responseTypes'][0]['type'];


### PR DESCRIPTION
Sometimes, Discord API can return response without body (HTTP 204 - No content).
This will result in the following stack exception since current code is always attempting to deserialize content into JSON :

```
InvalidArgumentException: json_decode error: Syntax error in /var/www/seat/vendor/guzzlehttp/guzzle/src/functions.php:304Stack trace:

#0 /var/www/seat/vendor/restcord/restcord/src/DiscordClient.php(228): GuzzleHttp\json_decode('')
#1 /var/www/seat/vendor/restcord/restcord/src/DiscordClient.php(183): RestCord\DiscordClient->convertResponseToResult('guild', Array, Object(GuzzleHttp\Psr7\Response), Object(GuzzleHttp\Command\Command))
#2 /var/www/seat/vendor/guzzlehttp/command/src/ServiceClient.php(215): RestCord\DiscordClient->RestCord\{closure}(Object(GuzzleHttp\Psr7\Response), Object(GuzzleHttp\Psr7\Request), Object(GuzzleHttp\Command\Command))
#3 /var/www/seat/vendor/guzzlehttp/command/src/ServiceClient.php(177): GuzzleHttp\Command\ServiceClient->transformResponseToResult(Object(GuzzleHttp\Psr7\Response), Object(GuzzleHttp\Psr7\Request), Object(GuzzleHttp\Command\Command))
#4 [internal function]: GuzzleHttp\Command\ServiceClient->GuzzleHttp\Command\{closure}()
#5 /var/www/seat/vendor/guzzlehttp/promises/src/Coroutine.php(122): Generator->send(Object(GuzzleHttp\Psr7\Response))
#6 /var/www/seat/vendor/guzzlehttp/promises/src/Promise.php(203): GuzzleHttp\Promise\Coroutine->_handleSuccess(Object(GuzzleHttp\Psr7\Response))
#7 /var/www/seat/vendor/guzzlehttp/promises/src/Promise.php(156): GuzzleHttp\Promise\Promise::callHandler(1, Object(GuzzleHttp\Psr7\Response), Array)
#8 /var/www/seat/vendor/guzzlehttp/promises/src/TaskQueue.php(47): GuzzleHttp\Promise\Promise::GuzzleHttp\Promise\{closure}()
#9 /var/www/seat/vendor/guzzlehttp/guzzle/src/Handler/CurlMultiHandler.php(96): GuzzleHttp\Promise\TaskQueue->run()
#10 /var/www/seat/vendor/guzzlehttp/guzzle/src/Handler/CurlMultiHandler.php(123): GuzzleHttp\Handler\CurlMultiHandler->tick()
#11 /var/www/seat/vendor/guzzlehttp/promises/src/Promise.php(246): GuzzleHttp\Handler\CurlMultiHandler->execute(true)
#12 /var/www/seat/vendor/guzzlehttp/promises/src/Promise.php(223): GuzzleHttp\Promise\Promise->invokeWaitFn()
#13 /var/www/seat/vendor/guzzlehttp/promises/src/Promise.php(267): GuzzleHttp\Promise\Promise->waitIfPending()
#14 /var/www/seat/vendor/guzzlehttp/promises/src/Promise.php(225): GuzzleHttp\Promise\Promise->invokeWaitList()
#15 /var/www/seat/vendor/guzzlehttp/promises/src/Promise.php(62): GuzzleHttp\Promise\Promise->waitIfPending()
#16 /var/www/seat/vendor/guzzlehttp/promises/src/Coroutine.php(65): GuzzleHttp\Promise\Promise->wait()
#17 /var/www/seat/vendor/guzzlehttp/promises/src/Promise.php(246): GuzzleHttp\Promise\Coroutine->GuzzleHttp\Promise\{closure}(true)
#18 /var/www/seat/vendor/guzzlehttp/promises/src/Promise.php(223): GuzzleHttp\Promise\Promise->invokeWaitFn()
#19 /var/www/seat/vendor/guzzlehttp/promises/src/Promise.php(62): GuzzleHttp\Promise\Promise->waitIfPending()
#20 /var/www/seat/vendor/guzzlehttp/promises/src/Coroutine.php(85): GuzzleHttp\Promise\Promise->wait(true)
#21 /var/www/seat/vendor/guzzlehttp/command/src/ServiceClient.php(77): GuzzleHttp\Promise\Coroutine->wait()
#22 /var/www/seat/vendor/guzzlehttp/command/src/ServiceClient.php(153): GuzzleHttp\Command\ServiceClient->execute(Object(GuzzleHttp\Command\Command))
#23 /var/www/seat/vendor/restcord/restcord/src/OverriddenGuzzleClient.php(86): GuzzleHttp\Command\ServiceClient->__call('addGuildMember', Array)
```

The current commit is handling 204 response and ignoring JSON deserialization when there is no body.