### PR TITLE
Update Model\Channel\Message to use 'int' for $edited_timestamp inste…

### DIFF
--- a/src/Model/Channel/Message.php
+++ b/src/Model/Channel/Message.php
@@ -77,7 +77,7 @@ class Message {
 	/**
 	 * when this message was edited (or null if never)
 	 *
-	 * @var ISO8601 timestamp
+	 * @var int
 	 */
 	public $edited_timestamp;
 


### PR DESCRIPTION
Update Model\Channel\Message to use 'int' for $edited_timestamp instead of ISO8601 to keep in line with $timestamp

Otherwise JsonMapper keeps failing with "Class '\RestCord\Model\Channel\ISO8601' not found"