### PR TITLE
Removing responseType for getPinnedMessages()

### DIFF
--- a/src/Resources/service_description-v6.json
+++ b/src/Resources/service_description-v6.json
@@ -1860,12 +1860,6 @@
                 "url": "/channels/{channel.id}/pins",
                 "description": "",
                 "responseNote": "Returns all pinned messages in the channel as an array of message objects.",
-                "responseTypes": [
-                    {
-                        "name": "message",
-                        "type": "channel/message"
-                    }
-                ],
                 "parameters": {
                     "channel.id": {
                         "type": "snowflake",


### PR DESCRIPTION
Removing the `responseTypes` for this so it's consistent with [`getChannelMessages `](https://github.com/restcord/restcord/blob/master/src/Resources/service_description-v6.json#L1326).  This resolves the following error when trying to obtain a list of pinned messages:

```
[2018-09-02 21:36:02] local.ERROR: There was an error executing the getPinnedMessages command: JsonMapper::map() requires first argument to be an object, array given. {"exception":"[object] (GuzzleHttp\\Command\\Exception\\CommandException(code: 0): There was an error executing the getPinnedMessages command: JsonMapper::map() requires first argument to be an object, array given. at /Users/bkuhl/Personal/myproject/vendor/guzzlehttp/command/src/Exception/CommandException.php:57, InvalidArgumentException(code: 0): JsonMapper::map() requires first argument to be an object, array given. at /Users/bkuhl/Personal/myproject/vendor/netresearch/jsonmapper/src/JsonMapper.php:126)
```