### PR TITLE
Excluding dev dependencies when used in other projects

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,5 +3,4 @@
 /.gitignore         export-ignore
 /.styleci.yml       export-ignore
 /.travis.yml        export-ignore
-/CONTRIBUTING.md    export-ignore
 /tests              export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Ignore all test and documentation with "export-ignore".
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.styleci.yml       export-ignore
+/.travis.yml        export-ignore
+/CONTRIBUTING.md    export-ignore
+/tests              export-ignore


### PR DESCRIPTION
Currently when restcord is included in other projects, `tests/` and all files related to the development of this project are also brought in.  This PR ignores those files when restcord is being `composer require`'d but still provides those files during a `git clone`.  This helps keep docker containers lightweight.