### PR TITLE
Update service_description-v6.json

### DIFF
--- a/src/Resources/service_description-v6.json
+++ b/src/Resources/service_description-v6.json
@@ -403,7 +403,6 @@
                         "location": "json",
                         "type": "bool",
                         "description": "if the user is muted",
-                        "default": false,
                         "extra": {
                             "Permission": "MUTE_MEMBERS"
                         }
@@ -412,7 +411,6 @@
                         "location": "json",
                         "type": "bool",
                         "description": "if the user is deafened",
-                        "default": false,
                         "extra": {
                             "Permission": "DEAFEN_MEMBERS"
                         }
@@ -459,7 +457,6 @@
                         "location": "json",
                         "type": "bool",
                         "description": "if the user is muted",
-                        "default": false,
                         "extra": {
                             "Permission": "MUTE_MEMBERS"
                         }
@@ -468,7 +465,6 @@
                         "location": "json",
                         "type": "bool",
                         "description": "if the user is deafened",
-                        "default": false,
                         "extra": {
                             "Permission": "DEAFEN_MEMBERS"
                         }


### PR DESCRIPTION
This removes a bug where you are unable to modify a server member unless they are in voice chat in the server at the time of the api call.

This is due to the discord API returning a 400 error if mute and/or deaf parameters are passed while the user is not in voice...