### PR TITLE
Update service_description-v6.json

### DIFF
--- a/src/Resources/service_description-v6.json
+++ b/src/Resources/service_description-v6.json
@@ -403,7 +403,6 @@
                         "location": "json",
                         "type": "bool",
                         "description": "if the user is muted",
-                        "default": false,
                         "extra": {
                             "Permission": "MUTE_MEMBERS"
                         }
@@ -412,7 +411,6 @@
                         "location": "json",
                         "type": "bool",
                         "description": "if the user is deafened",
-                        "default": false,
                         "extra": {
                             "Permission": "DEAFEN_MEMBERS"
                         }
@@ -459,14 +457,12 @@
                         "location": "json",
                         "type": "bool",
                         "description": "if the user is muted",
-                        "default": false,
                         "extra": {
                             "Permission": "MUTE_MEMBERS"
                         }
                     },
                     "deaf": {
                         "location": "json",
-                        "type": "bool",
                         "description": "if the user is deafened",
                         "default": false,
                         "extra": {


### PR DESCRIPTION
Update the service description to ensure that mute and deaf parameters are only sent when necessary. If they are sent when the user is not in a voice channel then discord will return a 400 error.