### PR TITLE
Only remove default if the parameter is not required

### DIFF
--- a/src/DiscordClient.php
+++ b/src/DiscordClient.php
@@ -357,8 +357,8 @@ class DiscordClient
                 $this->updateParameterTypes($parameterConfig);
                 if (!isset($parameterConfig['required'])) {
                     $parameterConfig['required'] = false;
+                    unset($parameterConfig['default']);
                 }
-                unset($parameterConfig['default']);
             }
         }
 


### PR DESCRIPTION
By only removing the default parameter if it's not required, the package will help the user if he didn't set it.