### PR TITLE
Fix Modify Channel verb

### DIFF
--- a/src/Resources/service_description-v6.json
+++ b/src/Resources/service_description-v6.json
@@ -1216,7 +1216,7 @@
                 "link": "https://discordapp.com/developers/docs/resources/channel#modify-channel",
                 "resource": "channel",
                 "name": "Modify Channel",
-                "method": "PUT/PATCH",
+                "method": "PATCH",
                 "url": "/channels/{channel.id}",
                 "description": "Update a channels settings. Requires the 'MANAGE_CHANNELS' permission for the guild.  Fires a Channel Update Gateway event. If modifying a category, individual Channel Update events will fire for each child channel that also changes. For the PATCH method, all the JSON Params are optional.",
                 "responseNote": "Returns a channel on success, and a 400 BAD REQUEST on invalid parameters.",


### PR DESCRIPTION
The Modify Channel verb is defined as "PUT/PATCH" which results in an error when trying to use the modifyChannel method. I understand this is pulled from an external service which parses the Discord docs, so I've created a PR over there to fix the root cause (https://github.com/aequasi/discord-service-definition-generator/pull/6). However this PR at least fixes the issue on the restcord repo for now, until the external service can be updated to generate the correct value.