### PR TITLE
Fixed 400 "Bad Request" when User is not in Voice Channel

### DIFF
--- a/src/Resources/service_description-v6.json
+++ b/src/Resources/service_description-v6.json
@@ -459,7 +459,6 @@
                         "location": "json",
                         "type": "bool",
                         "description": "if the user is muted",
-                        "default": false,
                         "extra": {
                             "Permission": "MUTE_MEMBERS"
                         }
@@ -468,7 +467,6 @@
                         "location": "json",
                         "type": "bool",
                         "description": "if the user is deafened",
-                        "default": false,
                         "extra": {
                             "Permission": "DEAFEN_MEMBERS"
                         }


### PR DESCRIPTION
If User is not in Voice Channel "mute" and "deaf" must not be set.
Else an Error 400 is returned.