### PR TITLE
Now allowing monolog v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php":                        "^5.6|^7.0",
         "guzzlehttp/guzzle":          "^6.3",
         "guzzlehttp/guzzle-services": "^1.0",
-        "monolog/monolog":            "^1.22",
+        "monolog/monolog":            "^1.22|^2.0",
         "netresearch/jsonmapper":     "^1.4",
         "symfony/options-resolver":   "^2.6|^3.0|^4.0"
     },


### PR DESCRIPTION
Under the covers the monolog dependency is merely being instantiated and passed to guzzle.  Guzzle merely cares about the [psr logging implementation](https://github.com/guzzle/guzzle/blob/6.3.3/composer.json#L23) so it doesn't care if it's monolog v1 or monolog v2.  This PR opens up the versioning so that either can be used.

If you're curious you can check out the [change logs for v2](https://github.com/Seldaek/monolog/blob/2.0.0/UPGRADE.md).