### PR TITLE
Add premium_since to GuildMember model

### DIFF
--- a/src/Model/Guild/GuildMember.php
+++ b/src/Model/Guild/GuildMember.php
@@ -27,10 +27,17 @@ class GuildMember {
 
 	/**
 	 * when the user joined the guild
-	 *
-	 * @var \DateTimeImmutable
-	 */
+     *
+     * @var \DateTimeImmutable
+     */
 	public $joined_at;
+
+	/**
+	 * when the user started boosting the guild
+	 *
+	 * @var \DateTimeImmutable|null
+	 */
+	public $premium_since;
 
 	/**
 	 * whether the user is muted in voice channels

--- a/src/Resources/service_description-v6.json
+++ b/src/Resources/service_description-v6.json
@@ -3204,6 +3204,11 @@
                         "type": "ISO8601 timestamp",
                         "description": "when the user joined the guild"
                     },
+                    "premium_since?": {
+                        "location": "json",
+                        "type": "ISO8601 timestamp",
+                        "description": "when the user started boosting the guild"
+                    },
                     "deaf": {
                         "location": "json",
                         "type": "boolean",


### PR DESCRIPTION
Fixes #115 

Note that I was unable to utilise the downloadServiceDefinition binary, as it is dependent upon the [discord-service-definition web resource](https://discord-service-definition.herokuapp.com/) that no longer appears to exist. Accordingly, GuildMember.php had to be edited manually, along with the service definition file.