### PR TITLE
Updated Discord's API URL

### DIFF
--- a/src/DiscordClient.php
+++ b/src/DiscordClient.php
@@ -145,7 +145,7 @@ class DiscordClient
                 'logger'            => new Logger('Logger'),
                 'rateLimitProvider' => new MemoryRateLimitProvider(),
                 'throwOnRatelimit'  => false,
-                'apiUrl'            => "https://discordapp.com/api/v{$currentVersion}/",
+                'apiUrl'            => "https://discord.com/api/v{$currentVersion}/",
                 'tokenType'         => 'Bot',
                 'cacheDir'          => __DIR__.'/../../../cache/',
                 'guzzleOptions'     => [],


### PR DESCRIPTION
From the announcement made in the Developers server: 

:mega: API Updates :mega: 

Discord has finally made the switch to discord.com :tada:

With this change also means that the API endpoint is moving too! Please start moving your libraries, webhooks, and integrations over to using discord.com in place of discordapp.com.

We currently plan to start requiring the new domain later this year for third party developers on November 7th, 2020. We will be sending out more formal notices (system DMs and account emails) to announce this breaking change in the coming weeks.