### PR TITLE
Fix RateLimiter (exclude minor parameters)

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -10,7 +10,6 @@ enabled:
   - newline_after_open_tag
 
 disabled:
-  - phpdoc_to_comment
   - unalign_equals
   - no_empty_phpdoc
 

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -10,6 +10,7 @@ enabled:
   - newline_after_open_tag
 
 disabled:
+  - phpdoc_to_comment
   - unalign_equals
   - no_empty_phpdoc
 

--- a/src/RateLimit/Provider/AbstractRateLimitProvider.php
+++ b/src/RateLimit/Provider/AbstractRateLimitProvider.php
@@ -109,12 +109,14 @@ abstract class AbstractRateLimitProvider
      */
     protected function stripMinorParameters(string $url) : string
     {
-        $matches = null;
+        $matches = [];
         if (
-            preg_match('/^(https:\/\/discord\.com\/api\/v6\/channels\/\d*).*?$/', $url, $matches) ||
-            preg_match('/^(https:\/\/discord\.com\/api\/v6\/guilds\/\d*).*?$/', $url, $rmatchesesult) ||
-            preg_match('/^(https:\/\/discord\.com\/api\/v6\/users\/@me\/guilds\/\d*).*?$/', $url, $matches) || 
-            preg_match('/^(https:\/\/discord\.com\/api\/v6\/webhooks\/\d*).*?$/', $url, $matches)
+            (
+                preg_match('/^(https:\/\/discord\.com\/api\/v6\/channels\/\d*).*?$/', $url, $matches) === 1 ||
+                preg_match('/^(https:\/\/discord\.com\/api\/v6\/guilds\/\d*).*?$/', $url, $matches) === 1 ||
+                preg_match('/^(https:\/\/discord\.com\/api\/v6\/users\/@me\/guilds\/\d*).*?$/', $url, $matches) === 1 || 
+                preg_match('/^(https:\/\/discord\.com\/api\/v6\/webhooks\/\d*).*?$/', $url, $matches) === 1
+            ) && count($matches) === 2
         ) {
             $url = $matches[1] . preg_replace('/[0-9]+/', '', substr($url, strlen($matches[1])));
         }

--- a/src/RateLimit/Provider/AbstractRateLimitProvider.php
+++ b/src/RateLimit/Provider/AbstractRateLimitProvider.php
@@ -38,7 +38,9 @@ abstract class AbstractRateLimitProvider
             $route = 'DELETE-' . $route;
         }
 
-        return $route;
+        $stripped = $this->stripMinorParameters($route);
+
+        return $stripped;
     }
 
     /**
@@ -95,4 +97,28 @@ abstract class AbstractRateLimitProvider
      * @param ResponseInterface $response The resolved response.
      */
     abstract public function setRequestAllowance(RequestInterface $request, ResponseInterface $response);
+
+    /**
+     * Method to match out major parameters of the route and
+     * remove minor parameters / numbers. This has to be done
+     * to ensure correct rate limiting according to: 
+     * https://discord.com/developers/docs/topics/rate-limits
+     *
+     * @param string $url
+     * @return string
+     */
+    protected function stripMinorParameters(string $url) : string
+    {
+        $matches = null;
+        if (
+            preg_match('/^(https:\/\/discord\.com\/api\/v6\/channels\/\d*).*?$/', $url, $matches) ||
+            preg_match('/^(https:\/\/discord\.com\/api\/v6\/guilds\/\d*).*?$/', $url, $rmatchesesult) ||
+            preg_match('/^(https:\/\/discord\.com\/api\/v6\/users\/@me\/guilds\/\d*).*?$/', $url, $matches) || 
+            preg_match('/^(https:\/\/discord\.com\/api\/v6\/webhooks\/\d*).*?$/', $url, $matches)
+        ) {
+            $url = $matches[1] . preg_replace('/[0-9]+/', '', substr($url, strlen($matches[1])));
+        }
+
+        return $url;
+    }
 }

--- a/src/RateLimit/Provider/AbstractRateLimitProvider.php
+++ b/src/RateLimit/Provider/AbstractRateLimitProvider.php
@@ -112,10 +112,10 @@ abstract class AbstractRateLimitProvider
         $matches = [];
         if (
             (
-                preg_match('/^(https:\/\/discord\.com\/api\/v6\/channels\/\d*).*?$/', $url, $matches) === 1 ||
-                preg_match('/^(https:\/\/discord\.com\/api\/v6\/guilds\/\d*).*?$/', $url, $matches) === 1 ||
-                preg_match('/^(https:\/\/discord\.com\/api\/v6\/users\/@me\/guilds\/\d*).*?$/', $url, $matches) === 1 || 
-                preg_match('/^(https:\/\/discord\.com\/api\/v6\/webhooks\/\d*).*?$/', $url, $matches) === 1
+                preg_match('/^(https:\/\/discord\.com\/api\/v\d+\/channels\/\d*).*?$/', $url, $matches) === 1 ||
+                preg_match('/^(https:\/\/discord\.com\/api\/v\d+\/guilds\/\d*).*?$/', $url, $matches) === 1 ||
+                preg_match('/^(https:\/\/discord\.com\/api\/v\d+\/users\/@me\/guilds\/\d*).*?$/', $url, $matches) === 1 || 
+                preg_match('/^(https:\/\/discord\.com\/api\/v\d+\/webhooks\/\d*).*?$/', $url, $matches) === 1
             ) && count($matches) === 2
         ) {
             $url = $matches[1] . preg_replace('/[0-9]+/', '', substr($url, strlen($matches[1])));

--- a/src/RateLimit/Provider/AbstractRateLimitProvider.php
+++ b/src/RateLimit/Provider/AbstractRateLimitProvider.php
@@ -124,3 +124,4 @@ abstract class AbstractRateLimitProvider
         return $url;
     }
 }
+

--- a/src/RateLimit/Provider/AbstractRateLimitProvider.php
+++ b/src/RateLimit/Provider/AbstractRateLimitProvider.php
@@ -32,9 +32,10 @@ abstract class AbstractRateLimitProvider
      */
     public function getRoute(RequestInterface $request)
     {
-        $route = $request->getUri()->__toString();
-        if ($request->getMethod() === 'DELETE' && strpos($request->getUri(), 'messages') !== false) {
-            $route = 'DELETE-'.$request->getUri();
+        $route = (string)$request->getUri();
+
+        if ($request->getMethod() === 'DELETE' && strpos($route, 'messages') !== false) {
+            $route = 'DELETE-' . $route;
         }
 
         return $route;

--- a/src/RateLimit/RateLimiter.php
+++ b/src/RateLimit/RateLimiter.php
@@ -97,7 +97,7 @@ class RateLimiter
      * Logs a request which is being delayed by a specified amount of time.
      *
      * @param RequestInterface $request request being delayed.
-     * @param float             $delay   The amount of time that the request is delayed for.
+     * @param float            $delay   The amount of time that the request is delayed for.
      */
     protected function log(RequestInterface $request, $delay)
     {

--- a/src/RateLimit/RateLimiter.php
+++ b/src/RateLimit/RateLimiter.php
@@ -82,10 +82,8 @@ class RateLimiter
                 $this->delay($delay);
             }
 
-            /* 
-             * Sets the time when this request is beind made,
-             * which allows calculation of allowance later on.
-             */
+            // Sets the time when this request is beind made,
+            // which allows calculation of allowance later on.
             $this->provider->setLastRequestTime($request);
 
             // Set the allowance when the response was received

--- a/src/RateLimit/RateLimiter.php
+++ b/src/RateLimit/RateLimiter.php
@@ -88,7 +88,7 @@ class RateLimiter
              */
             $this->provider->setLastRequestTime($request);
 
-            /* Set the allowance when the response was received */
+            // Set the allowance when the response was received
             return $handler($request, $options)->then($this->setAllowance($request));
         };
     }

--- a/src/RateLimit/RateLimiter.php
+++ b/src/RateLimit/RateLimiter.php
@@ -114,7 +114,7 @@ class RateLimiter
      * Formats a request and delay time as a log message.
      *
      * @param RequestInterface $request The request being logged.
-     * @param float             $delay   The amount of time that the request is delayed for.
+     * @param float            $delay   The amount of time that the request is delayed for.
      *
      * @return string Log message
      */

--- a/src/RateLimit/RateLimiter.php
+++ b/src/RateLimit/RateLimiter.php
@@ -71,7 +71,7 @@ class RateLimiter
     public function __invoke(callable $handler)
     {
         return function (RequestInterface $request, $options) use ($handler) {
-            /* Amount of time to delay the request by */
+            // Amount of time to delay the request by
             while(($delay = $this->getDelay($request)) > 0) {
                 // Throw an exception if configured to do so, this will NOT delay the request and raise an Exception
                 if ($this->options['throwOnRatelimit']) {

--- a/src/RateLimit/RateLimiter.php
+++ b/src/RateLimit/RateLimiter.php
@@ -73,7 +73,7 @@ class RateLimiter
         return function (RequestInterface $request, $options) use ($handler) {
             /* Amount of time to delay the request by */
             while(($delay = $this->getDelay($request)) > 0) {
-                /* Throw an exception if configured to do so, this will NOT delay the request and raise an Exception */
+                // Throw an exception if configured to do so, this will NOT delay the request and raise an Exception
                 if ($this->options['throwOnRatelimit']) {
                     throw new RatelimitException($request->getMethod().' '.$request->getUri());
                 }

--- a/src/RateLimit/RateLimiter.php
+++ b/src/RateLimit/RateLimiter.php
@@ -216,3 +216,4 @@ class RateLimiter
         };
     }
 }
+


### PR DESCRIPTION
Information: https://github.com/restcord/restcord/issues/122

Primary task of this PR is to exclude minor parameters from the rate limiters lookup table. The reason behind this is explained in the linked issue and on the rate limiting documentation of the discord API https://discord.com/developers/docs/topics/rate-limits

- [x] Implement
- [x] Test 
- [ ] Refactor (Get root & endpoint templates from definition rather than using regex to improve maintainability and DRY). *