### PR TITLE
Fix style CI

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -10,7 +10,6 @@ enabled:
   - newline_after_open_tag
 
 disabled:
-  - phpdoc_to_comment
   - unalign_equals
   - no_empty_phpdoc
 


### PR DESCRIPTION
phpdoc_to_comment cant be disabled since it is not enabled in the preset.
https://docs.styleci.io/presets