### PR TITLE
Added with_counts query parameter to getGuild

### DIFF
--- a/src/Resources/service_description-v6.json
+++ b/src/Resources/service_description-v6.json
@@ -80,6 +80,12 @@
                         "type": "snowflake",
                         "location": "uri",
                         "required": true
+                    },
+                    "with_counts": {
+                        "location": "query",
+                        "type": "integer",
+                        "description": "when true, will return approximate member and presence counts for the guild",
+                        "default": false
                     }
                 },
                 "parametersArray": false

--- a/src/Resources/service_description-v6.json
+++ b/src/Resources/service_description-v6.json
@@ -83,7 +83,7 @@
                     },
                     "with_counts": {
                         "location": "query",
-                        "type": "integer",
+                        "type": "boolean",
                         "description": "when true, will return approximate member and presence counts for the guild",
                         "default": false
                     }


### PR DESCRIPTION
There's a new query parameter available for the `getGuild` endpoint.  This PR adds support for it.  I've tested this and verified it pulls in the counts as expected.