### PR TITLE
Allowing avatars to be treated as strings

### DIFF
--- a/src/DiscordClient.php
+++ b/src/DiscordClient.php
@@ -378,7 +378,12 @@ class DiscordClient
             $parameterConfig['type'] = 'boolean';
         }
 
-        if (in_array($parameterConfig['type'], ['avatar data', 'avatar data string', 'file contents'])) {
+        $stringTypes = [
+            'avatar data',
+            'avatar data string',
+            'file contents',
+        ];
+        if (in_array($parameterConfig['type'], $stringTypes, true)) {
             $parameterConfig['type'] = 'string';
         }
 

--- a/src/DiscordClient.php
+++ b/src/DiscordClient.php
@@ -378,7 +378,7 @@ class DiscordClient
             $parameterConfig['type'] = 'boolean';
         }
 
-        if ($parameterConfig['type'] === 'file contents') {
+        if (in_array($parameterConfig['type'], ['avatar data', 'avatar data string', 'file contents'])) {
             $parameterConfig['type'] = 'string';
         }
 


### PR DESCRIPTION
This PR resolves https://github.com/restcord/restcord/issues/121.

I ran into this specific scenario when upgrading to `dev-master` and webhook creation.  The issue is resolved for webhook creation with the suggested change in the linked issue.