### PR TITLE
Adding public properties for a guild's with_counts parameters

### DIFF
--- a/src/Model/Guild/Guild.php
+++ b/src/Model/Guild/Guild.php
@@ -228,6 +228,20 @@ class Guild {
 	public $splash;
 
 	/**
+	 * approximent number of members
+	 *
+	 * @var int|null
+	 */
+	public $approximate_member_count;
+
+	/**
+	 * approximent number of people currently present
+	 *
+	 * @var int|null
+	 */
+	public $approximate_presence_count;
+
+	/**
 	 * the id of the channel to which system messages are sent
 	 *
 	 * @var int


### PR DESCRIPTION
When I implemented https://github.com/restcord/restcord/pull/133, I was testing with an older version of restcord.  With the newer version, these public properties must be in place in order for these numbers to actually come through on the `Guild`.

I have tested this with the latest commit on `dev-master` and the figures do come through as expected when these properties are in place.