### PR TITLE
Fix MessageFormatter for Guzzle7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type":         "library",
     "require":      {
         "php":                        "^7.3|^8.0",
-        "guzzlehttp/guzzle":          "^6.3|^7.0",
+        "guzzlehttp/guzzle":          "^7.0",
         "guzzlehttp/guzzle-services": "^1.0",
         "monolog/monolog":            "^1.22|^2.0",
         "netresearch/jsonmapper":     "^1.4",

--- a/src/Logging/MessageFormatter.php
+++ b/src/Logging/MessageFormatter.php
@@ -14,6 +14,7 @@
 namespace RestCord\Logging;
 
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * @author Aaron Scherer <aequasi@gmail.com>
@@ -44,9 +45,9 @@ class MessageFormatter extends \GuzzleHttp\MessageFormatter
      */
     public function format(
         RequestInterface $request,
-        $response = null,
-        $error = null
-    ) {
+        ?ResponseInterface $response = null,
+        ?\Throwable $error = null
+    ): string {
         $template = parent::format($request, $response, $error);
 
         return str_replace($this->token, '<TOKEN>', $template);


### PR DESCRIPTION
Adds the typehint's to the MessageFormatter to be compatible to the parent implementation. This will inevitably remove support for Guzzle 6 (what would not work anyways).