### PR TITLE
Error Fix 1/2 | Guild Icon outputs 404.

### DIFF
--- a/src/Constants.php
+++ b/src/Constants.php
@@ -23,4 +23,5 @@ class Constants
     const CDN_URL    = 'https://cdn.discordapp.com/';
 
     const AVATAR_URL = self::CDN_URL.'avatars/';
+    const ICON_URL = self::CDN_URL.'icons/';
 }


### PR DESCRIPTION
This error fix fixes an error in the link. Where the current commit says /avatars/ it now says /icons/.