### PR TITLE
Update compatibility for Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "guzzlehttp/guzzle-services": "^1.0",
         "monolog/monolog":            "^1.22|^2.0",
         "netresearch/jsonmapper":     "^1.4",
-        "symfony/options-resolver":   "^3.4|^4.4|^5.1"
+        "symfony/options-resolver":   "^3.4|^4.4|^5.1|^6.0"
     },
     "autoload":     {
         "psr-4": {


### PR DESCRIPTION
While developing (in dev), because of "gossi/php-code-generator" which only supports Symfony 3, you will need to replace my changes with :

```"symfony/options-resolver":   "^6.0.0 as v3.4.47"```

if you actually want the package to properly function for now.