### PR TITLE
Fix Discord API v9 issues with GuildScheduledEvent

### DIFF
--- a/docs/_docs/Audit-log/Get Guild Audit Log.md
+++ b/docs/_docs/Audit-log/Get Guild Audit Log.md
@@ -7,7 +7,7 @@ order: 1
 # `getGuildAuditLog`
 
 ```php
-$client->audit-log->getGuildAuditLog($parameters);
+$client->auditLog->getGuildAuditLog($parameters);
 ```
 
 ## Description

--- a/docs/_docs/Guild-scheduled-event/Create Guild Scheduled Event.md
+++ b/docs/_docs/Guild-scheduled-event/Create Guild Scheduled Event.md
@@ -7,7 +7,7 @@ order: 2
 # `createGuildScheduledEvent`
 
 ```php
-$client->guild-scheduled-event->createGuildScheduledEvent($parameters);
+$client->guildScheduledEvent->createGuildScheduledEvent($parameters);
 ```
 
 ## Description

--- a/docs/_docs/Guild-scheduled-event/Create Guild Scheduled Event.md
+++ b/docs/_docs/Guild-scheduled-event/Create Guild Scheduled Event.md
@@ -21,13 +21,13 @@ Name | Type | Required | Default
 --- | --- | --- | ---
 guild.id | snowflake | true | *null*
 channel_id | snowflake * | false | *null*
-entity_metadata | entity metadata | false | *null*
+entity_metadata | array | false | *null*
 name | string | false | *null*
-privacy_level | privacy level | false | *null*
-scheduled_start_time | ISO8601 timestamp | false | *null*
-scheduled_end_time | ISO8601 timestamp | false | *null*
+privacy_level | integer | false | *null*
+scheduled_start_time | string | false | *null*
+scheduled_end_time | string | false | *null*
 description | string | false | *null*
-entity_type | entity type | false | *null*
+entity_type | integer | false | *null*
 
 ## Response
 

--- a/docs/_docs/Guild-scheduled-event/Modify Guild Scheduled Event.md
+++ b/docs/_docs/Guild-scheduled-event/Modify Guild Scheduled Event.md
@@ -21,14 +21,14 @@ Name | Type | Required | Default
 --- | --- | --- | ---
 guild.id | snowflake | true | *null*
 channel_id | snowflake | false | *null*
-entity_metadata | entity metadata | false | *null*
+entity_metadata | array | false | *null*
 name | string | false | *null*
-privacy_level | privacy level | false | *null*
-scheduled_start_time | ISO8601 timestamp | false | *null*
-scheduled_end_time | ISO8601 timestamp | false | *null*
+privacy_level | integer | false | *null*
+scheduled_start_time | string | false | *null*
+scheduled_end_time | string | false | *null*
 description | string | false | *null*
-entity_type | event entity type | false | *null*
-status | event status | false | *null*
+entity_type | array | false | *null*
+status | integer | false | *null*
 
 ## Response
 

--- a/docs/_docs/Guild-template/Create Guild from Guild Template.md
+++ b/docs/_docs/Guild-template/Create Guild from Guild Template.md
@@ -7,7 +7,7 @@ order: 2
 # `createGuildFromGuildTemplate`
 
 ```php
-$client->guild-template->createGuildFromGuildTemplate($parameters);
+$client->guildTemplate->createGuildFromGuildTemplate($parameters);
 ```
 
 ## Description

--- a/docs/_docs/Stage-instance/Create Stage Instance.md
+++ b/docs/_docs/Stage-instance/Create Stage Instance.md
@@ -7,7 +7,7 @@ order: 1
 # `createStageInstance`
 
 ```php
-$client->stage-instance->createStageInstance($parameters);
+$client->stageInstance->createStageInstance($parameters);
 ```
 
 ## Description

--- a/src/Interfaces/GuildScheduledEvent.php
+++ b/src/Interfaces/GuildScheduledEvent.php
@@ -21,7 +21,7 @@ interface GuildScheduledEvent {
 	/**
 	 * @see https://discordapp.com/developers/docs/resources/guild-scheduled-event#create-guild-scheduled-event
 	 *
-	 * @param array $options ['guild.id' => 'snowflake', 'channel_id' => 'snowflake *', 'entity_metadata' => 'entity metadata', 'name' => 'string', 'privacy_level' => 'privacy level', 'scheduled_start_time' => 'ISO8601 timestamp', 'scheduled_end_time' => 'ISO8601 timestamp', 'description' => 'string', 'entity_type' => 'entity type']
+	 * @param array $options ['guild.id' => 'snowflake', 'channel_id' => 'snowflake *', 'entity_metadata' => 'array', 'name' => 'string', 'privacy_level' => 'integer', 'scheduled_start_time' => 'string', 'scheduled_end_time' => 'string', 'description' => 'string', 'entity_type' => 'integer']
 	 * @return array
 	 */
 	public function createGuildScheduledEvent(array $options);
@@ -61,7 +61,7 @@ interface GuildScheduledEvent {
 	/**
 	 * @see https://discordapp.com/developers/docs/resources/guild-scheduled-event#modify-guild-scheduled-event
 	 *
-	 * @param array $options ['guild.id' => 'snowflake', 'channel_id' => 'snowflake', 'entity_metadata' => 'entity metadata', 'name' => 'string', 'privacy_level' => 'privacy level', 'scheduled_start_time' => 'ISO8601 timestamp', 'scheduled_end_time' => 'ISO8601 timestamp', 'description' => 'string', 'entity_type' => 'event entity type', 'status' => 'event status']
+	 * @param array $options ['guild.id' => 'snowflake', 'channel_id' => 'snowflake', 'entity_metadata' => 'array', 'name' => 'string', 'privacy_level' => 'integer', 'scheduled_start_time' => 'string', 'scheduled_end_time' => 'string', 'description' => 'string', 'entity_type' => 'integer', 'status' => 'integer']
 	 * @return array
 	 */
 	public function modifyGuildScheduledEvent(array $options);

--- a/src/Model/GuildScheduledEvent/GuildScheduledEvent.php
+++ b/src/Model/GuildScheduledEvent/GuildScheduledEvent.php
@@ -56,14 +56,14 @@ class GuildScheduledEvent {
 	/**
 	 * additional metadata for the guild scheduled event
 	 *
-	 * @var entity metadata
+	 * @var array
 	 */
 	public $entity_metadata;
 
 	/**
 	 * the type of the scheduled event
 	 *
-	 * @var scheduled entity type
+	 * @var int
 	 */
 	public $entity_type;
 
@@ -91,7 +91,7 @@ class GuildScheduledEvent {
 	/**
 	 * the privacy level of the scheduled event
 	 *
-	 * @var privacy level
+	 * @var int
 	 */
 	public $privacy_level;
 
@@ -112,7 +112,7 @@ class GuildScheduledEvent {
 	/**
 	 * the status of the scheduled event
 	 *
-	 * @var event status
+	 * @var int
 	 */
 	public $status;
 

--- a/src/Model/GuildScheduledEvent/GuildScheduledEventUser.php
+++ b/src/Model/GuildScheduledEvent/GuildScheduledEventUser.php
@@ -49,14 +49,14 @@ class GuildScheduledEventUser {
 	/**
 	 * the entity metadata of the scheduled event
 	 *
-	 * @var entity metadata
+	 * @var array
 	 */
 	public $entity_metadata;
 
 	/**
 	 * the entity type of the scheduled event
 	 *
-	 * @var event entity type
+	 * @var int
 	 */
 	public $entity_type;
 
@@ -70,14 +70,14 @@ class GuildScheduledEventUser {
 	/**
 	 * how many users to receive from the event
 	 *
-	 * @var number
+	 * @var string Number as a string
 	 */
 	public $limit = '100';
 
 	/**
 	 * guild member data for this user for the guild which this event belongs to, if any
 	 *
-	 * @var guild member
+	 * @var GuildScheduledEventUser
 	 */
 	public $member;
 

--- a/src/Resources/service_description-v9.json
+++ b/src/Resources/service_description-v9.json
@@ -2609,7 +2609,7 @@
                     },
                     "entity_metadata": {
                         "location": "json",
-                        "type": "entity metadata",
+                        "type": "array",
                         "description": "the entity metadata of the scheduled event"
                     },
                     "name": {
@@ -2619,18 +2619,18 @@
                     },
                     "privacy_level": {
                         "location": "json",
-                        "type": "privacy level",
+                        "type": "integer",
                         "description": "the privacy level of the scheduled event"
                     },
                     "scheduled_start_time": {
                         "location": "json",
-                        "type": "ISO8601 timestamp",
-                        "description": "the time to schedule the scheduled event"
+                        "type": "string",
+                        "description": "the time to schedule the scheduled event (ISO8601 timestamp)"
                     },
                     "scheduled_end_time": {
                         "location": "json",
-                        "type": "ISO8601 timestamp",
-                        "description": "the time when the scheduled event is scheduled to end"
+                        "type": "string",
+                        "description": "the time when the scheduled event is scheduled to end (ISO8601 timestamp)"
                     },
                     "description": {
                         "location": "json",
@@ -2639,7 +2639,7 @@
                     },
                     "entity_type": {
                         "location": "json",
-                        "type": "entity type",
+                        "type": "integer",
                         "description": "the entity type of the scheduled event"
                     }
                 },
@@ -2682,7 +2682,7 @@
                     },
                     "entity_metadata": {
                         "location": "json",
-                        "type": "entity metadata",
+                        "type": "array",
                         "description": "the entity metadata of the scheduled event"
                     },
                     "name": {
@@ -2692,17 +2692,17 @@
                     },
                     "privacy_level": {
                         "location": "json",
-                        "type": "privacy level",
+                        "type": "integer",
                         "description": "the privacy level of the scheduled event"
                     },
                     "scheduled_start_time": {
                         "location": "json",
-                        "type": "ISO8601 timestamp",
+                        "type": "string",
                         "description": "the time to schedule the scheduled event"
                     },
                     "scheduled_end_time": {
                         "location": "json",
-                        "type": "ISO8601 timestamp",
+                        "type": "string",
                         "description": "the time when the scheduled event is scheduled to end"
                     },
                     "description": {
@@ -2712,12 +2712,12 @@
                     },
                     "entity_type": {
                         "location": "json",
-                        "type": "event entity type",
+                        "type": "integer",
                         "description": "the entity type of the scheduled event"
                     },
                     "status": {
                         "location": "json",
-                        "type": "event status",
+                        "type": "integer",
                         "description": "the status of the scheduled event"
                     }
                 },
@@ -5819,23 +5819,23 @@
                     },
                     "scheduled_start_time": {
                         "location": "json",
-                        "type": "ISO8601 timestamp",
+                        "type": "string",
                         "description": "the time the scheduled event will start"
                     },
                     "scheduled_end_time": {
                         "location": "json",
-                        "type": "ISO8601 timestamp",
+                        "type": "string",
                         "nullable": true,
                         "description": "the time the scheduled event will end, required if entity_type is EXTERNAL"
                     },
                     "privacy_level": {
                         "location": "json",
-                        "type": "privacy level",
+                        "type": "integer",
                         "description": "the privacy level of the scheduled event"
                     },
                     "status": {
                         "location": "json",
-                        "type": "event status",
+                        "type": "integer",
                         "description": "the status of the scheduled event"
                     },
                     "entity_type": {
@@ -5851,7 +5851,7 @@
                     },
                     "entity_metadata": {
                         "location": "json",
-                        "type": "entity metadata",
+                        "type": "array",
                         "nullable": true,
                         "description": "additional metadata for the guild scheduled event"
                     },
@@ -5902,7 +5902,7 @@
                     },
                     "entity_metadata": {
                         "location": "json",
-                        "type": "entity metadata",
+                        "type": "array",
                         "description": "the entity metadata of the scheduled event"
                     },
                     "name": {
@@ -5912,17 +5912,17 @@
                     },
                     "privacy_level": {
                         "location": "json",
-                        "type": "privacy level",
+                        "type": "integer",
                         "description": "the privacy level of the scheduled event"
                     },
                     "scheduled_start_time": {
                         "location": "json",
-                        "type": "ISO8601 timestamp",
+                        "type": "string",
                         "description": "the time to schedule the scheduled event"
                     },
                     "scheduled_end_time": {
                         "location": "json",
-                        "type": "ISO8601 timestamp",
+                        "type": "string",
                         "description": "the time when the scheduled event is scheduled to end"
                     },
                     "description": {
@@ -5932,12 +5932,12 @@
                     },
                     "entity_type": {
                         "location": "json",
-                        "type": "event entity type",
+                        "type": "integer",
                         "description": "the entity type of the scheduled event"
                     },
                     "status": {
                         "location": "json",
-                        "type": "event status",
+                        "type": "integer",
                         "description": "the status of the scheduled event"
                     },
                     "limit": {

--- a/src/Resources/service_description-v9.json
+++ b/src/Resources/service_description-v9.json
@@ -1352,7 +1352,7 @@
             }
         },
         "application": {},
-        "audit-log": {
+        "auditLog": {
             "getGuildAuditLog": {
                 "link": "https://discordapp.com/developers/docs/resources/audit-log#get-guild-audit-log",
                 "resource": "audit-log",
@@ -2566,7 +2566,7 @@
                 "parametersArray": false
             }
         },
-        "guild-scheduled-event": {
+        "guildScheduledEvent": {
             "listScheduledEventsForGuild": {
                 "link": "https://discordapp.com/developers/docs/resources/guild-scheduled-event#list-scheduled-events-for-guild",
                 "resource": "guild-scheduled-event",
@@ -2778,7 +2778,7 @@
                 "parametersArray": false
             }
         },
-        "guild-template": {
+        "guildTemplate": {
             "getGuildTemplate": {
                 "link": "https://discordapp.com/developers/docs/resources/guild-template#get-guild-template",
                 "resource": "guild-template",
@@ -2990,7 +2990,7 @@
                 "parametersArray": false
             }
         },
-        "stage-instance": {
+        "stageInstance": {
             "createStageInstance": {
                 "link": "https://discordapp.com/developers/docs/resources/stage-instance#create-stage-instance",
                 "resource": "stage-instance",
@@ -5093,7 +5093,7 @@
                 }
             }
         },
-        "audit-log": {
+        "auditLog": {
             "auditLog": {
                 "link": "https://discordapp.com/developers/docs/resources/audit-log#audit-log-object",
                 "resource": "audit-log",
@@ -5778,7 +5778,7 @@
                 }
             }
         },
-        "guild-scheduled-event": {
+        "guildScheduledEvent": {
             "guildScheduledEvent": {
                 "link": "https://discordapp.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object",
                 "resource": "guild-scheduled-event",
@@ -5965,7 +5965,7 @@
                 }
             }
         },
-        "guild-template": {
+        "guildTemplate": {
             "guildTemplate": {
                 "link": "https://discordapp.com/developers/docs/resources/guild-template#guild-template-object",
                 "resource": "guild-template",
@@ -6188,7 +6188,7 @@
                 }
             }
         },
-        "stage-instance": {
+        "stageInstance": {
             "stageInstance": {
                 "link": "https://discordapp.com/developers/docs/resources/stage-instance#stage-instance-object",
                 "resource": "stage-instance",


### PR DESCRIPTION
This fixes the ability to use these models from the client, as they were broken due to the hyphens:

- AuditLog (replace `$client->audit-log` with `$client->auditLog`)
- GuildScheduledEvent (replace `$client->guild-scheduled-event` with `$client->guildScheduledEvent`)
- GuildTemplate (replace `$client->guild-template` with `$client->guildTemplate`)
- StageInstance (replace `$client->stage-instance` with `$client->stageInstance`)

Additionally, it fixes the parameter types for `GuildScheduledEvent`. For example, 'scheduled_start_time' was listed as type 'ISO8601 timestamp' because that's what the Discord API says. But it's actually a PHP string, in the format of an ISO8601-compatible date/time.

With these parameter type fixes in place, it means that it's actually possible to create an event now, using code like this:

```php
$client->guildScheduledEvent->createGuildScheduledEvent([
    'guild.id' => $guildId,
    'name' => 'Event Name',
    'description' => 'Event Description',
    'scheduled_start_time' => '2022-01-16T07:30:00+00:00',
    'scheduled_end_time' => '2022-01-16T09:30:00+00:00',
    'privacy_level' => 2, // GUILD_ONLY
    'entity_type' => 3, // EXTERNAL
    'entity_metadata' => [
        'location' => 'https://example.com',
    ],
]);
```

See the relevant documentation here: https://discord.com/developers/docs/resources/guild-scheduled-event#create-guild-scheduled-event

I have successfully created events in my Discord server using this, so I can verify that it works for scheduled events.

There may be outstanding parameter type issues for AuditLog, GuildTemplate, and StageInstance. However I'll leave that to someone else to fix if there is in fact an issue.