### PR TITLE
Fix issue with Create Guild Ban optional parameters

### DIFF
--- a/docs/_docs/Guild/Create Guild Ban.md
+++ b/docs/_docs/Guild/Create Guild Ban.md
@@ -21,8 +21,8 @@ Name | Type | Required | Default
 --- | --- | --- | ---
 guild.id | snowflake | true | *null*
 user.id | snowflake | true | *null*
-delete-message-days? | integer | false | *null*
-reason? | string | false | *null*
+delete-message-days | integer | false | *null*
+reason | string | false | *null*
 
 ## Response
 

--- a/src/Interfaces/Guild.php
+++ b/src/Interfaces/Guild.php
@@ -53,7 +53,7 @@ interface Guild {
 	/**
 	 * @see https://discordapp.com/developers/docs/resources/guild#create-guild-ban
 	 *
-	 * @param array $options ['guild.id' => 'snowflake', 'user.id' => 'snowflake', 'delete-message-days?' => 'integer', 'reason?' => 'string']
+	 * @param array $options ['guild.id' => 'snowflake', 'user.id' => 'snowflake', 'delete-message-days' => 'integer', 'reason' => 'string']
 	 * @return array Returns a 204 empty response on success.
 	 */
 	public function createGuildBan(array $options);

--- a/src/Resources/service_description-v6.json
+++ b/src/Resources/service_description-v6.json
@@ -3318,12 +3318,6 @@
                 "description": "",
                 "type": "object",
                 "properties": {
-                    "reason": {
-                        "location": "json",
-                        "type": "string",
-                        "nullable": true,
-                        "description": "the reason for the ban"
-                    },
                     "user": {
                         "location": "json",
                         "type": "object",
@@ -3510,6 +3504,7 @@
                     "reason": {
                         "location": "query",
                         "type": "string",
+                        "nullable": true,
                         "description": "reason for the ban"
                     },
                     "permissions": {

--- a/src/Resources/service_description-v6.json
+++ b/src/Resources/service_description-v6.json
@@ -677,12 +677,12 @@
                         "location": "uri",
                         "required": true
                     },
-                    "delete-message-days?": {
+                    "delete-message-days": {
                         "location": "query",
                         "type": "integer",
                         "description": "number of days to delete messages for (0-7)"
                     },
-                    "reason?": {
+                    "reason": {
                         "location": "query",
                         "type": "string",
                         "description": "reason for the ban"
@@ -3502,12 +3502,12 @@
                             "Permission": "MOVE_MEMBERS"
                         }
                     },
-                    "delete-message-days?": {
+                    "delete-message-days": {
                         "location": "query",
                         "type": "integer",
                         "description": "number of days to delete messages for (0-7)"
                     },
-                    "reason?": {
+                    "reason": {
                         "location": "query",
                         "type": "string",
                         "description": "reason for the ban"
@@ -3670,7 +3670,7 @@
                         "type": "optional audit entry info",
                         "description": "additional info for certain action types"
                     },
-                    "reason?": {
+                    "reason": {
                         "location": "json",
                         "type": "string",
                         "description": "the reason for the change (0-512 characters)"


### PR DESCRIPTION
This should fix the issue reported in #118 - the parameter names in Restcord erroneously include the ? used in the Discord API docs to represent an optional parameter.

I also noticed a situation where the 'reason' parameter was duplicated, and removed one of them.