### PR TITLE
fix: drop explicit monolog dependency in favor of psr/log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,9 @@
         "php":                        "^7.3|^8.0",
         "guzzlehttp/guzzle":          "^7.0",
         "guzzlehttp/guzzle-services": "^1.0",
-        "monolog/monolog":            "^1.22|^2.0",
         "netresearch/jsonmapper":     "^1.4",
-        "symfony/options-resolver":   "^3.4|^4.4|^5.1|^6.0"
+        "symfony/options-resolver":   "^3.4|^4.4|^5.1|^6.0",
+        "psr/log": "^2.0|^3.0"
     },
     "autoload":     {
         "psr-4": {

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,7 +72,7 @@ Name | Type | Required | Default | Description
 --- | --- | --- | --- | ---
 token | string | Yes | ~ | Your bot token
 version | string | No | `1.0.0` | The version of the API to use. Should probably be left alone
-logger | Monolog\Logger | false | `new Logger('Logger')` | An instance of a Monolog\Logger
+logger | Psr\Log\LoggerInterface | false | `new Logger('Logger')` | An instance of Psr\Log\LoggerInterface - e.g. Monolog\Logger
 throwOnRatelimit | bool | false | `false` | Whether or not an exception is thrown when a ratelimit is supposed to hit
 apiUrl | string | false | `https://discordapp.com/api/v6` | Should leave this alone.
 tokenType | string | false | `Bot` | Either `Bot` or `OAuth`

--- a/src/DiscordClient.php
+++ b/src/DiscordClient.php
@@ -21,8 +21,8 @@ use GuzzleHttp\Command\Result;
 use GuzzleHttp\HandlerStack;
 use function GuzzleHttp\json_decode;
 use GuzzleHttp\Middleware;
-use Monolog\Logger;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
 use RestCord\Logging\MessageFormatter;
 use RestCord\RateLimit\Provider\AbstractRateLimitProvider;
 use RestCord\RateLimit\Provider\MemoryRateLimitProvider;
@@ -57,7 +57,7 @@ class DiscordClient
     private $categories = [];
 
     /**
-     * @var Logger
+     * @var LoggerInterface
      */
     private $logger;
 


### PR DESCRIPTION
The LoggerInterface is enough to declare the expected type on the logger option.

Helps in migrating a laravel 9 to laravel 10 based project - see #187 